### PR TITLE
Release: xdotool/xclip text input with terminal detection

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -195,17 +195,17 @@ pub async fn run_daemon(config: config::Config) -> Result<()> {
                                             state = AppState::Typing;
 
                                             if let Err(e) =
-                                                input::type_text(&processed_text)
+                                                input::paste_text(&processed_text)
                                             {
                                                 tracing::error!(
-                                                    "Failed to type text: {}",
+                                                    "Failed to paste text: {}",
                                                     e
                                                 );
                                                 if let Err(e2) =
-                                                    input::paste_text(&processed_text)
+                                                    input::type_text(&processed_text)
                                                 {
                                                     tracing::error!(
-                                                        "Clipboard paste also failed: {}",
+                                                        "Direct type also failed: {}",
                                                         e2
                                                     );
                                                 }
@@ -220,7 +220,7 @@ pub async fn run_daemon(config: config::Config) -> Result<()> {
                                                 "Falling back to raw transcription"
                                             );
                                             state = AppState::Typing;
-                                            let _ = input::type_text(&corrected);
+                                            let _ = input::paste_text(&corrected);
                                         }
                                     }
                                 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,66 +1,119 @@
 use anyhow::{Context, Result};
-use enigo::{Enigo, Keyboard, Settings};
 
-/// Type text into the active window using enigo.
+/// Known terminal WM_CLASS values (lowercase for comparison).
+const TERMINAL_CLASSES: &[&str] = &[
+    "gnome-terminal",
+    "kitty",
+    "alacritty",
+    "wezterm",
+    "foot",
+    "konsole",
+    "xterm",
+    "urxvt",
+    "terminator",
+    "tilix",
+    "st-256color",
+    "sakura",
+];
+
+/// Check if the active window is a terminal emulator.
+fn is_active_window_terminal() -> bool {
+    let window_id = std::process::Command::new("xdotool")
+        .arg("getactivewindow")
+        .output()
+        .ok();
+
+    let Some(output) = window_id else {
+        return false;
+    };
+
+    let id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if id.is_empty() {
+        return false;
+    }
+
+    let wm_class = std::process::Command::new("xprop")
+        .args(["-id", &id, "WM_CLASS"])
+        .output()
+        .ok();
+
+    let Some(output) = wm_class else {
+        return false;
+    };
+
+    let class_str = String::from_utf8_lossy(&output.stdout).to_lowercase();
+    TERMINAL_CLASSES.iter().any(|t| class_str.contains(t))
+}
+
+/// Type text into the active window using xdotool.
 pub fn type_text(text: &str) -> Result<()> {
     if text.is_empty() {
         return Ok(());
     }
 
-    let mut enigo =
-        Enigo::new(&Settings::default()).map_err(|e| anyhow::anyhow!("enigo init: {}", e))?;
+    tracing::info!("Typing {} chars via xdotool", text.len());
 
-    tracing::info!("Typing {} chars into active window", text.len());
+    let status = std::process::Command::new("xdotool")
+        .args(["type", "--clearmodifiers", "--", text])
+        .status()
+        .context("running xdotool type")?;
 
-    // Type the text character by character for reliability
-    enigo
-        .text(text)
-        .map_err(|e| anyhow::anyhow!("enigo type: {}", e))?;
+    if !status.success() {
+        anyhow::bail!("xdotool type failed with status {}", status);
+    }
 
     Ok(())
 }
 
-/// Type text using clipboard paste for better Unicode support.
+/// Type text using clipboard paste via xclip + xdotool.
+/// Auto-detects terminal windows and uses Ctrl+Shift+V instead of Ctrl+V.
 pub fn paste_text(text: &str) -> Result<()> {
-    use arboard::Clipboard;
-    use enigo::{Direction, Key};
-
     if text.is_empty() {
         return Ok(());
     }
 
-    // Save current clipboard content
-    let mut clipboard = Clipboard::new().context("opening clipboard")?;
-    let old_content = clipboard.get_text().ok();
+    // Set clipboard via xclip
+    let mut child = std::process::Command::new("xclip")
+        .args(["-selection", "clipboard"])
+        .stdin(std::process::Stdio::piped())
+        .spawn()
+        .context("running xclip")?;
 
-    // Set new content
-    clipboard
-        .set_text(text)
-        .context("setting clipboard text")?;
-
-    // Simulate Ctrl+V
-    let mut enigo =
-        Enigo::new(&Settings::default()).map_err(|e| anyhow::anyhow!("enigo init: {}", e))?;
-
-    enigo
-        .key(Key::Control, Direction::Press)
-        .map_err(|e| anyhow::anyhow!("key press: {}", e))?;
-    enigo
-        .key(Key::Unicode('v'), Direction::Press)
-        .map_err(|e| anyhow::anyhow!("key press v: {}", e))?;
-    enigo
-        .key(Key::Unicode('v'), Direction::Release)
-        .map_err(|e| anyhow::anyhow!("key release v: {}", e))?;
-    enigo
-        .key(Key::Control, Direction::Release)
-        .map_err(|e| anyhow::anyhow!("key release: {}", e))?;
-
-    // Small delay then restore clipboard
-    std::thread::sleep(std::time::Duration::from_millis(100));
-    if let Some(old) = old_content {
-        let _ = clipboard.set_text(old);
+    if let Some(mut stdin) = child.stdin.take() {
+        use std::io::Write;
+        stdin
+            .write_all(text.as_bytes())
+            .context("writing to xclip")?;
     }
 
-    tracing::info!("Pasted {} chars via clipboard", text.len());
+    let status = child.wait().context("waiting for xclip")?;
+    if !status.success() {
+        anyhow::bail!("xclip failed with status {}", status);
+    }
+
+    // Use Ctrl+Shift+V for terminals, Ctrl+V for GUI apps
+    let is_terminal = is_active_window_terminal();
+    let paste_key = if is_terminal {
+        "ctrl+shift+v"
+    } else {
+        "ctrl+v"
+    };
+
+    tracing::info!(
+        "Pasting {} chars via {} (terminal={})",
+        text.len(),
+        paste_key,
+        is_terminal
+    );
+
+    let status = std::process::Command::new("xdotool")
+        .args(["key", "--clearmodifiers", paste_key])
+        .status()
+        .context("running xdotool key")?;
+
+    if !status.success() {
+        anyhow::bail!("xdotool key {} failed with status {}", paste_key, status);
+    }
+
     Ok(())
 }


### PR DESCRIPTION
## Summary
Promote develop to main. Includes:
- Replace enigo with xdotool + xclip for reliable X11 text input
- Auto-detect terminal windows via WM_CLASS for Ctrl+Shift+V paste
- Clipboard paste as primary input method

## Test plan
- [x] Browser text input - works
- [x] Claude Code (terminal) text input - works