### PR TITLE
Prevent duplicate daemon instances and fix autostart Exec path

### DIFF
--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -10,10 +10,18 @@ use super::{IpcRequest, IpcResponse};
 pub async fn start() -> Result<mpsc::Receiver<IpcRequest>> {
     let sock_path = super::socket_path();
 
-    // Remove stale socket file if it exists
+    // Check for already-running instance via the socket
     if sock_path.exists() {
-        std::fs::remove_file(&sock_path)
-            .with_context(|| format!("removing stale socket {}", sock_path.display()))?;
+        match std::os::unix::net::UnixStream::connect(&sock_path) {
+            Ok(_) => {
+                anyhow::bail!("koe daemon is already running (socket {} is active)", sock_path.display());
+            }
+            Err(_) => {
+                // Socket is stale — remove and continue
+                std::fs::remove_file(&sock_path)
+                    .with_context(|| format!("removing stale socket {}", sock_path.display()))?;
+            }
+        }
     }
 
     let listener = UnixListener::bind(&sock_path)

--- a/src/ui/settings_window.rs
+++ b/src/ui/settings_window.rs
@@ -726,7 +726,14 @@ fn create_autostart_entry() -> anyhow::Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let exe = std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("koe"));
+    let local_bin = dirs::home_dir()
+        .unwrap_or_default()
+        .join(".local/bin/koe");
+    let exe = if local_bin.exists() {
+        local_bin
+    } else {
+        std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("koe"))
+    };
     let content = format!(
         "[Desktop Entry]\nType=Application\nName=koe\nExec={}\nX-GNOME-Autostart-enabled=true\n",
         exe.display()


### PR DESCRIPTION
## Summary
- IPC サーバー起動時にソケットへの接続を試み、既存デーモンが稼働中なら明確なエラーで終了（二重起動防止）
- stale ソケットは従来通り削除して正常起動
- autostart の .desktop Exec パスを `~/.local/bin/koe` ラッパー優先に変更（worktree/debug パス固定問題の解消）

## Test plan
- [ ] koe 起動 → トレイアイコン1つ
- [ ] もう1つ koe 起動 → "koe daemon is already running" エラーで終了
- [ ] デーモン kill → stale ソケット残る → 再起動で正常起動
- [ ] Settings UI で autostart ON → .desktop の Exec が ~/.local/bin/koe を指すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)