### PR TITLE
Change AI model selection from free text to dropdown

### DIFF
--- a/src/ui/settings_window.rs
+++ b/src/ui/settings_window.rs
@@ -565,6 +565,7 @@ fn build_ai_page(
         let current_model = ol.model.clone();
         let list = ollama_model_list.clone();
         let combo = ollama_model_combo.clone();
+        let custom_entry = ollama_model_custom.clone();
 
         let (tx, rx) = std::sync::mpsc::channel::<Vec<String>>();
         std::thread::spawn(move || {
@@ -586,7 +587,10 @@ fn build_ai_page(
                     if let Some(idx) = models.iter().position(|m| *m == current_model) {
                         combo.set_selected(idx as u32);
                     } else {
+                        // Current model not in fetched list: fall back to "Other"
+                        // and pre-populate the custom entry so the model name is preserved.
                         combo.set_selected(models.len() as u32); // "Other"
+                        custom_entry.set_text(&current_model);
                     }
                     gtk4::glib::ControlFlow::Break
                 }


### PR DESCRIPTION
## Summary
- Claude: ComboRow with現行世代モデル (sonnet-4-6 / opus-4-6 / haiku-4-5) + "Other" で自由入力
- Ollama: `/api/tags` からインストール済みモデルを動的取得して ComboRow に表示、取得失敗時は現在の設定値 + "Other" にフォールバック
- 入力ミス防止 & モデル名を覚えていなくても選択可能に

## Test plan
- [ ] Claude モデル選択: プルダウンから既知モデルを選べること
- [ ] Claude "Other" 選択時にカスタム入力欄が表示されること
- [ ] Ollama 起動中: インストール済みモデルがプルダウンに列挙されること
- [ ] Ollama 停止中: 現在の設定値 + "Other" でフォールバックすること
- [ ] Test Connection が ComboRow / Custom Entry どちらからでも正しいモデル名を使うこと
- [ ] 設定保存 & リロード後に選択が維持されること

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)