### PR TITLE
Restore suppress_non_speech_tokens (renamed to set_suppress_nst in 0.15)

### DIFF
--- a/src/recognition/whisper_local.rs
+++ b/src/recognition/whisper_local.rs
@@ -64,6 +64,7 @@ impl SpeechRecognizer for WhisperLocalRecognizer {
             params.set_print_realtime(false);
             params.set_print_timestamps(false);
             params.set_suppress_blank(true);
+            params.set_suppress_nst(true);
 
             state
                 .full(params, &samples)


### PR DESCRIPTION
The whisper-rs 0.15 upgrade dropped the suppress_non_speech_tokens call because the method was renamed to set_suppress_nst. Re-enable it to prevent non-speech artifacts in transcription output.