### PR TITLE
Add semantic versioning (v0.2.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,36 @@
+# koe - Project Instructions
+
+## Versioning
+
+セマンティックバージョニング (semver) で管理する。
+
+- バージョンは `Cargo.toml` の `version` フィールドが source of truth
+- `koe --version` で確認可能（clap の `version` 属性）
+- main にマージする PR で機能追加・変更がある場合、`Cargo.toml` のバージョンを更新すること
+  - 機能追加: minor バージョンを上げる (e.g., 0.2.0 → 0.3.0)
+  - バグ修正のみ: patch バージョンを上げる (e.g., 0.2.0 → 0.2.1)
+- マージ後に `git tag v<version>` でタグを打つ
+- リファクタリングのみ・CI/設定変更のみの PR ではバージョンを上げなくてよい
+
+## Build & Test
+
+```bash
+cargo check          # 型チェック
+cargo test           # テスト実行
+cargo build --release  # リリースビルド
+```
+
+## Architecture
+
+- `src/daemon.rs` — メインイベントループ（Idle → Recording → Processing → Typing）
+- `src/recognition/` — 音声認識（Whisper local / OpenAI API）
+- `src/ai/` — AI 後処理（Claude / Ollama）
+- `src/memory/` — 自動学習メモリ（用語辞書 + コンテキスト）
+- `src/config.rs` — 設定管理（`~/.config/koe/config.toml`）
+- `src/ui/` — GTK4/libadwaita 設定 UI（`--features gui`）
+
+## Worktree Convention
+
+- メインワークツリーでは直接編集しない（フックでブロック）
+- `git worktree add .worktrees/<name> -b <branch>` で作業用ワークツリーを作成
+- ブランチ命名: `feature/<name>`, `fix/<name>`, `chore/<name>`, `release/<name>`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "koe"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koe"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Ubuntu voice input system powered by Whisper + AI post-processing"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
-#[command(name = "koe", about = "Ubuntu voice input system")]
+#[command(name = "koe", about = "Ubuntu voice input system", version)]
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,


### PR DESCRIPTION
## Summary
- セマンティックバージョニングを導入
- R1+R2 (memory auto-learning) を含む現在の main を v0.2.0 とする
- `koe --version` でバージョン確認可能に
- CLAUDE.md にバージョン管理ルールを記載（main マージ時のバージョン更新を忘れないためのフック）

## Changes
| File | Change |
|------|--------|
| `Cargo.toml` | version 0.1.0 → 0.2.0 |
| `src/main.rs` | clap に `version` 属性追加 |
| `CLAUDE.md` | プロジェクト規約（versioning, build, architecture, worktree） |

## After merge
```bash
git tag v0.2.0
git push origin v0.2.0
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)