### PR TITLE
Narrow stale-socket detection to ConnectionRefused only

### DIFF
--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -16,10 +16,14 @@ pub async fn start() -> Result<mpsc::Receiver<IpcRequest>> {
             Ok(_) => {
                 anyhow::bail!("koe daemon is already running (socket {} is active)", sock_path.display());
             }
-            Err(_) => {
-                // Socket is stale — remove and continue
+            Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => {
+                // Socket is stale (no listener) — remove and continue
                 std::fs::remove_file(&sock_path)
                     .with_context(|| format!("removing stale socket {}", sock_path.display()))?;
+            }
+            Err(e) => {
+                // Unexpected error (permission denied, etc.) — do not remove, propagate
+                anyhow::bail!("cannot check existing socket {}: {}", sock_path.display(), e);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Only treat `ConnectionRefused` as a stale socket when checking for an existing daemon
- Propagate other errors (permission denied, resource unavailable, etc.) instead of blindly removing the socket, which could affect a live daemon

## Changed files
- `src/ipc/server.rs` — split `Err(_)` into `Err(e) if ConnectionRefused` (stale → remove) and `Err(e)` (unexpected → bail)

## Test plan
- [ ] Start daemon normally — verify no behavior change
- [ ] Kill daemon without cleanup (stale socket remains) — verify new daemon starts correctly
- [ ] Simulate permission error on socket — verify error is propagated, not silently removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)