### PR TITLE
Fix paste to wrong window when indicator is active

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1799,7 +1799,7 @@ dependencies = [
 
 [[package]]
 name = "koe"
-version = "0.3.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koe"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Ubuntu voice input system powered by Whisper + AI post-processing"
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -232,6 +232,7 @@ pub async fn run_daemon(mut config: config::Config) -> Result<()> {
 
     // Audio level forwarding task handle (active only during Recording)
     let mut audio_level_handle: Option<JoinHandle<()>> = None;
+    let mut active_window_id: Option<String> = None;
 
     // Set initial Whisper hint from memory
     if config.memory.enabled && !mem.terms.is_empty() {
@@ -358,6 +359,8 @@ pub async fn run_daemon(mut config: config::Config) -> Result<()> {
             Ok(hotkey::HotkeyEvent::RecordStart) => {
                 if state == AppState::Idle {
                     tracing::info!(">>> Recording started");
+                    // Capture the active window before showing indicator overlay
+                    active_window_id = input::capture_active_window();
                     state = AppState::Recording;
                     if let Err(e) = recorder.start() {
                         tracing::error!("Failed to start recording: {}", e);
@@ -482,7 +485,7 @@ pub async fn run_daemon(mut config: config::Config) -> Result<()> {
                                             notify_state_change(&state, &dbus_emitter, #[cfg(feature = "gui")] &tray_handle, #[cfg(feature = "gui")] &indicator_tx).await;
 
                                             if let Err(e) =
-                                                input::paste_text(&result.text)
+                                                input::paste_text(&result.text, active_window_id.as_deref())
                                             {
                                                 tracing::error!(
                                                     "Failed to paste text: {}",
@@ -516,7 +519,7 @@ pub async fn run_daemon(mut config: config::Config) -> Result<()> {
 
                                             state = AppState::Typing;
                                             notify_state_change(&state, &dbus_emitter, #[cfg(feature = "gui")] &tray_handle, #[cfg(feature = "gui")] &indicator_tx).await;
-                                            let _ = input::paste_text(&corrected);
+                                            let _ = input::paste_text(&corrected, active_window_id.as_deref());
                                         }
                                     }
                                 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -16,24 +16,28 @@ const TERMINAL_CLASSES: &[&str] = &[
     "sakura",
 ];
 
-/// Check if the active window is a terminal emulator.
-fn is_active_window_terminal() -> bool {
-    let window_id = std::process::Command::new("xdotool")
+/// Capture the current active window ID via xdotool.
+/// Call this before showing overlays (e.g. indicator window) to preserve
+/// the real target window for later paste operations.
+pub fn capture_active_window() -> Option<String> {
+    let output = std::process::Command::new("xdotool")
         .arg("getactivewindow")
         .output()
-        .ok();
-
-    let Some(output) = window_id else {
-        return false;
-    };
+        .ok()?;
 
     let id = String::from_utf8_lossy(&output.stdout).trim().to_string();
     if id.is_empty() {
-        return false;
+        None
+    } else {
+        tracing::debug!("Captured active window: {}", id);
+        Some(id)
     }
+}
 
+/// Check if the given window ID belongs to a terminal emulator.
+fn is_window_terminal(window_id: &str) -> bool {
     let wm_class = std::process::Command::new("xprop")
-        .args(["-id", &id, "WM_CLASS"])
+        .args(["-id", window_id, "WM_CLASS"])
         .output()
         .ok();
 
@@ -66,10 +70,18 @@ pub fn type_text(text: &str) -> Result<()> {
 }
 
 /// Type text using clipboard paste via xclip + xdotool.
-/// Auto-detects terminal windows and uses Ctrl+Shift+V instead of Ctrl+V.
-pub fn paste_text(text: &str) -> Result<()> {
+/// Uses a pre-captured window ID to determine terminal vs GUI paste key.
+/// If `target_window` is None, falls back to detecting the current active window.
+pub fn paste_text(text: &str, target_window: Option<&str>) -> Result<()> {
     if text.is_empty() {
         return Ok(());
+    }
+
+    // Focus the target window if we have one, to ensure paste goes to the right place
+    if let Some(wid) = target_window {
+        let _ = std::process::Command::new("xdotool")
+            .args(["windowfocus", "--sync", wid])
+            .status();
     }
 
     // Set clipboard via xclip
@@ -92,7 +104,15 @@ pub fn paste_text(text: &str) -> Result<()> {
     }
 
     // Use Ctrl+Shift+V for terminals, Ctrl+V for GUI apps
-    let is_terminal = is_active_window_terminal();
+    let is_terminal = match target_window {
+        Some(wid) => is_window_terminal(wid),
+        None => {
+            // Fallback: detect current active window
+            capture_active_window()
+                .map(|wid| is_window_terminal(&wid))
+                .unwrap_or(false)
+        }
+    };
     let paste_key = if is_terminal {
         "ctrl+shift+v"
     } else {
@@ -100,10 +120,11 @@ pub fn paste_text(text: &str) -> Result<()> {
     };
 
     tracing::info!(
-        "Pasting {} chars via {} (terminal={})",
+        "Pasting {} chars via {} (terminal={}, window={:?})",
         text.len(),
         paste_key,
-        is_terminal
+        is_terminal,
+        target_window
     );
 
     let status = std::process::Command::new("xdotool")


### PR DESCRIPTION
## Summary
- 録音開始時にアクティブウィンドウIDをキャプチャし、ペースト時にそのウィンドウを使用するように修正
- インジケーターオーバーレイが表示されている間にペーストすると、ターミナル判定が誤り ctrl+v が使われていたバグを修正
- paste_text() にターゲットウィンドウIDを渡し、xdotool windowfocus で正しいウィンドウにフォーカスしてからペースト

## Test plan
- [x] 全68テストパス
- [x] cargo check --features gui コンパイル成功
- [ ] ターミナルで1回目の音声入力が正しく ctrl+shift+v でペーストされること
- [ ] GUI アプリで ctrl+v が使われること

🤖 Generated with [Claude Code](https://claude.com/claude-code)