### PR TITLE
Add build quality rules to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,10 @@ cargo test           # テスト実行
 cargo build --release  # リリースビルド
 ```
 
+- Rust ファイルを変更した後は `cargo check` を実行して型エラーがないことを確認する
+- PR 作成前・コミット前は `cargo test && cargo clippy` も実行する
+- デーモン関連の変更時は、重複起動防止ロジック（PID ファイル or D-Bus 名）が壊れていないか確認する
+
 ## Architecture
 
 - `src/daemon.rs` — メインイベントループ（Idle → Recording → Processing → Typing）


### PR DESCRIPTION
## Summary
- Rust ファイル変更後の `cargo check` 実行ルールを追加
- PR/コミット前の `cargo test && cargo clippy` ルールを追加
- デーモン重複起動チェックの注意事項を追加

buggy code 削減のため、ビルド品質チェックを CLAUDE.md に明文化。

## Test plan
- [x] CLAUDE.md の差分が意図通りであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)