### PR TITLE
Fix release workflow: add glslc for Vulkan shader compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libasound2-dev libclang-dev libxkbcommon-dev libx11-dev libxi-dev libxext-dev libxtst-dev libxfixes-dev cmake libgtk-4-dev libadwaita-1-dev libvulkan-dev
+          sudo apt-get install -y libasound2-dev libclang-dev libxkbcommon-dev libx11-dev libxi-dev libxext-dev libxtst-dev libxfixes-dev cmake libgtk-4-dev libadwaita-1-dev libvulkan-dev glslc
       - name: Build release binary
         run: cargo build --release --locked
       - name: Package binary


### PR DESCRIPTION
## Summary
- Release ワークフローの Vulkan ビルドに必要な glslc パッケージを追加
- v0.5.0 の release ビルドが glslc 不足で失敗していた

## Test plan
- [ ] CI が通ること
- [ ] マージ後に v0.5.0 タグを再作成して release ビルドが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system dependencies for the release build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->