### PR TITLE
Harden supply chain security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -8,10 +8,15 @@ on:
   schedule:
     - cron: '0 0 * * 1'
 
+permissions: {}
+
 jobs:
   audit:
     name: cargo audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   check:
     name: cargo check

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in koe, please report it responsibly.
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Instead, please email: **shuhei0866@gmail.com**
+
+Include:
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+You should receive a response within 48 hours. We will work with you to understand and address the issue before any public disclosure.
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| latest  | Yes       |
+| < latest | No      |
+
+## Security Measures
+
+- All dependencies are audited weekly via `cargo audit`
+- GitHub Actions use SHA-pinned actions (not mutable tags)
+- Builds use `--locked` to ensure reproducible builds from `Cargo.lock`
+- Release binaries include SHA256 checksums


### PR DESCRIPTION
## Summary
- CI/audit ワークフローに `permissions: {}` を設定（最小権限の原則）
- Dependabot 有効化（cargo + github-actions の週次自動更新）
- SECURITY.md 追加（脆弱性報告の窓口）
- タグ保護ルールセット設定済み（`v*` の削除・上書き禁止）

## Test plan
- [ ] CI が通ること（permissions 変更で壊れていないか）
- [ ] Dependabot が正しく動作すること（マージ後に確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured Dependabot for automated weekly dependency update checks.
  * Applied minimal permission configuration to GitHub Actions workflows.

* **Documentation**
  * Added security policy outlining vulnerability disclosure and reporting procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->